### PR TITLE
fix main field package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "crumbsjs",
   "version": "0.1.1",
   "description": "A lightweight, intuitive, Vanilla ES6 fueled JS cookie library",
-  "main": "index.js",
+  "main": "dist/crumbs.js",
   "dependencies": {
     "jest": "^23.6.0",
     "lodash": "^1.3.1",


### PR DESCRIPTION
Hi,

The `main` field should specify your main dist file, to allow bundlers (rollup, webpack, etc) to find your file.

Fixes: #5